### PR TITLE
build(actions): add CI actions

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,35 @@
+name: Docker Image CI
+
+on:
+  schedule:
+    - cron: 0 0 * * 3
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        package:
+          - chromium
+          # - firefox
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get version
+        id: get_version
+        run: echo ::set-output name=result::$(make --file ${{ matrix.package }}/Makefile get-version)
+
+      - name: Build image
+        run: make --file ${{ matrix.package }}/Makefile build version=${{ steps.get_version.outputs.result }}
+
+      - name: Login into Docker
+        run: docker login --username=anatol1988 --password=${{ secrets.DOCKER_TOKEN }}
+
+      - name: Push image to Docker
+        run: docker push neuralegion/nextools-${{ matrix.package }}

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         package:
           - chromium
-          - firefox
+          # - firefox
 
     steps:
       - name: Checkout
@@ -84,18 +84,18 @@ jobs:
         if: steps.check_status.outputs.result == 'outdated'
         run: git push --force --tags origin master
 
-      - name: Docker GitHub Packages login
-        if: steps.check_status.outputs.result == 'outdated'
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login --username ${{ github.actor }} --password-stdin docker.pkg.github.com
+      # - name: Docker GitHub Packages login
+      #   if: steps.check_status.outputs.result == 'outdated'
+      #   run: echo ${{ secrets.GITHUB_TOKEN }} | docker login --username ${{ github.actor }} --password-stdin docker.pkg.github.com
 
-      - name: Docker GitHub Packages push
-        if: steps.check_status.outputs.result == 'outdated'
-        run: docker push docker.pkg.github.com/nextools/images/${{ matrix.package }}
+      # - name: Docker GitHub Packages push
+      #   if: steps.check_status.outputs.result == 'outdated'
+      #   run: docker push docker.pkg.github.com/nextools/images/${{ matrix.package }}
 
-      - name: Docker Hub login
+      - name: Login into Docker
         if: steps.check_status.outputs.result == 'outdated'
-        run: echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login --username nextoolsbot --password-stdin
+        run: docker login --username=anatol1988 --password=${{ secrets.DOCKER_TOKEN }}
 
-      - name: Docker Hub push
+      - name: Push image to Docker
         if: steps.check_status.outputs.result == 'outdated'
-        run: docker push nextools/${{ matrix.package }}
+        run: docker push neuralegion/nextools-${{ matrix.package }}

--- a/chromium/Makefile
+++ b/chromium/Makefile
@@ -9,11 +9,24 @@ get-version:
 		sh -c "apt-get update --quiet=2 && apt-cache policy chromium-browser | sed --regexp-extended --quiet 's/.*Candidate: ([0-9.]+)-.+/\1/p'"
 
 build:
-	@docker build --tag chromium --build-arg VERSION=$(version) $(CURRENT_DIR)
+	@docker build --tag nextools-chromium --build-arg VERSION=$(version) $(CURRENT_DIR)
 
 test:
-	@docker run --detach --publish 9222:9222 --name chromium chromium
-	@timeout 20s sh -c "trap 'docker container rm --force chromium' 0; until curl http://localhost:9222/json/version; do sleep 1; done"
+	@docker run --detach --publish 9222:9222 --name nextools-chromium nextools-chromium
+	@timeout 20s sh -c "trap 'docker container rm --force nextools-chromium' 0; until curl http://localhost:9222/json/version; do sleep 1; done"
+
+# tags:
+# 	@for i in 3 2 1 0 -1; do \
+# 		if [ $$i -ge 0 ]; then \
+# 			tag=`echo $(version) | sed --regexp-extended "s/(\.[0-9]+){$$i}$$//"`; \
+# 		else \
+# 			tag=latest; \
+# 		fi; \
+# 		echo $$tag; \
+# 		docker tag nextools-chromium docker.pkg.github.com/neuralegion/images/nextools-chromium:$$tag; \
+# 		docker tag nextools-chromium neuralegion/nextools-chromium:$$tag; \
+# 		git tag --force chromium@$$tag; \
+# 	done
 
 tags:
 	@for i in 3 2 1 0 -1; do \
@@ -23,7 +36,6 @@ tags:
 			tag=latest; \
 		fi; \
 		echo $$tag; \
-		docker tag chromium docker.pkg.github.com/nextools/images/chromium:$$tag; \
-		docker tag chromium nextools/chromium:$$tag; \
+		docker tag nextools-chromium neuralegion/nextools-chromium:$$tag; \
 		git tag --force chromium@$$tag; \
 	done

--- a/chromium/readme.md
+++ b/chromium/readme.md
@@ -12,16 +12,16 @@ Auto-updatable every 12 hours: Chromium version is split into multiple Docker ta
 ### Docker Hub
 
 ```sh
-docker run -it --rm -p 9222:9222 nextools/chromium:<TAG>
+docker run -it --rm -p 9222:9222 neuralegion/nextools-chromium:<TAG>
 ```
 
-### GitHub Packages
+<!-- ### GitHub Packages
 
 ```sh
 docker run -it --rm -p 9222:9222 docker.pkg.github.com/nextools/images/chromium:<TAG>
 ```
 
-See [login caveats](../readme.md#github-packages) in the root readme.
+See [login caveats](../readme.md#github-packages) in the root readme. -->
 
 ### Puppeteer
 
@@ -53,13 +53,13 @@ await browser.close()
 Container uses a `RD_PORT` [environment variable](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file), which is `9222` by default:
 
 ```
-docker run -it --rm -p 9223:9223 -e RD_PORT=9223 nextools/chromium:<TAG>
+docker run -it --rm -p 9223:9223 -e RD_PORT=9223 neuralegion/nextools-chromium:<TAG>
 ```
 
 ### pass additional Chromium arguments
 
 ```
-docker run -it --rm -p 9222:9222 nextools/chromium:<TAG> --some-chromium-arg
+docker run -it --rm -p 9222:9222 neuralegion/nextools-chromium:<TAG> --some-chromium-arg
 ```
 
 ### add custom fonts
@@ -67,5 +67,5 @@ docker run -it --rm -p 9222:9222 nextools/chromium:<TAG> --some-chromium-arg
 It's possible to mount a folder with custom fonts to be used later by Chromium: 
 
 ```
-docker run -it --rm -p 9222:9222 -v $(pwd)/path/to/fonts:/home/chromium/.fonts nextools/chromium:<TAG>
+docker run -it --rm -p 9222:9222 -v $(pwd)/path/to/fonts:/home/chromium/.fonts neuralegion/nextools-chromium:<TAG>
 ```

--- a/firefox/Makefile
+++ b/firefox/Makefile
@@ -10,17 +10,23 @@ get-version:
 
 build:
 	@_version=`echo $(version) | sed --regexp-extended s/a/~a/`
-	@docker build --tag firefox --build-arg VERSION=$$_version $(CURRENT_DIR)
+	@docker build --tag nextools-firefox --build-arg VERSION=$$_version $(CURRENT_DIR)
 
 test:
-	@docker run --detach --publish 9222:9222 --name firefox firefox
-	@timeout 20s sh -c "trap 'docker container rm --force firefox' 0; until curl http://localhost:9222/json/version; do sleep 1; done"
+	@docker run --detach --publish 9222:9222 --name nextools-firefox nextools-firefox
+	@timeout 20s sh -c "trap 'docker container rm --force nextools-firefox' 0; until curl http://localhost:9222/json/version; do sleep 1; done"
+
+# tags:
+# 	@for tag in $(version) latest; do \
+# 		echo $$tag; \
+# 		docker tag nextools-firefox docker.pkg.github.com/neuralegion/images/nextools-firefox:$$tag; \
+# 		docker tag nextools-firefox neuralegion/nextools-firefox:$$tag; \
+# 		git tag --force firefox@$$tag >/dev/null 2>&1; \
+# 	done
 
 tags:
 	@for tag in $(version) latest; do \
 		echo $$tag; \
-		docker tag firefox docker.pkg.github.com/nextools/images/firefox:$$tag; \
-		docker tag firefox nextools/firefox:$$tag; \
+		docker tag nextools-firefox neuralegion/nextools-firefox:$$tag; \
 		git tag --force firefox@$$tag >/dev/null 2>&1; \
 	done
-

--- a/firefox/profile/prefs.js
+++ b/firefox/profile/prefs.js
@@ -14,10 +14,42 @@ user_pref("browser.onboarding.enabled", false);
 user_pref("browser.tabs.warnOnClose", false);
 user_pref("browser.tabs.warnOnCloseOtherTabs", false);
 user_pref("browser.tabs.warnOnOpen", false);
-user_pref("browser.link.open_newwindow", 3);
+// optimize memory
+user_pref("browser.tabs.remote.autostart", false);
+
+/* Prop: browser.link.open_newwindow
+1 = force new window into same tab
+2 = allow link to open a new window
+3 = divert new window to a new tab (default)
+*/
+user_pref("browser.link.open_newwindow", 1);
+/* Prop: browser.link.open_newwindow.restriction
+0 = apply the setting under (browser.link.open_newwindow) to ALL new windows (even script windows)
+1 = override the setting under (browser.link.open_newwindow) and always use new windows
+2 = apply the setting under (browser.link.open_newwindow) to normal windows, but NOT to script windows with features (default)
+*/
 user_pref("browser.link.open_newwindow.restriction", 0);
+/* Prop: browser.link.open_newwindow.override.external
+-1 = apply the setting under (browser.link.open_newwindow) to external links (default)
+1 = open external links in the last active tab replacing the current page
+2 = open external links in a new window
+3 = open external links in a new tab in the last active window
+*/
+user_pref("browser.link.open_newwindow.override.external", 1);
 
 // updates
+user_pref("media.eme.enabled", false);
+user_pref("media.gmp-widevinecdm.enabled", false);
+user_pref("media.gmp-gmpopenh264.enabled", false);
+user_pref("media.gmp-gmpopenh264.autoupdate", false);
+user_pref("media.gmp-manager.cert.checkAttributes", false);
+user_pref("media.gmp-gmpopenh264.visible", false);
+user_pref("media.gmp-manager.cert.checkAttributes", false);
+user_pref("media.gmp-manager.cert.requireBuiltIn", false);
+user_pref("media.gmp-manager.url", "about:blank");
+user_pref("media.gmp-provider.enabled", false);
+user_pref("media.gmp-widevinecdm.visible", false)
+user_pref("media.gmp.trial-create.enabled", false);
 user_pref("app.update.enabled", false);
 user_pref("extensions.update.enabled", false);
 user_pref("extensions.update.autoUpdateDefault", false);
@@ -29,7 +61,6 @@ user_pref("app.update.service.enabled", false);
 user_pref("app.update.staging.enabled", false);
 user_pref("lightweightThemes.update.enabled", false);
 user_pref("browser.search.update", false);
-user_pref("browser.aboutHomeSnippets.updateUrl", "data:,");
 
 // crash reports
 user_pref("dom.ipc.plugins.flash.subprocess.crashreporter.enabled", false);
@@ -42,9 +73,12 @@ user_pref("browser.chrome.errorReporter.enabled", false);
 user_pref("browser.chrome.errorReporter.submitUrl", "");
 
 // telemetry and data reporting
+user_pref("toolkit.telemetry.unifiedIsOptIn", false);
+user_pref("toolkit.telemetry.prompted", 2);
+user_pref("toolkit.telemetry.rejected", true);
 user_pref("toolkit.telemetry.unified", false);
 user_pref("toolkit.telemetry.enabled", false);
-user_pref("toolkit.telemetry.server", "data:,");
+user_pref("toolkit.telemetry.server", "");
 user_pref("toolkit.telemetry.archive.enabled", false);
 user_pref("toolkit.telemetry.cachedClientID", "");
 user_pref("toolkit.telemetry.newProfilePing.enabled", false);
@@ -74,3 +108,55 @@ user_pref("experiments.manifest.uri", "");
 user_pref("experiments.supported", false);
 user_pref("experiments.activeExperiment", false);
 user_pref("network.allow-experiments", false);
+
+// Marionette settings
+user_pref("marionette.log.level", "debug");
+
+// Enable authless screencapture
+user_pref("media.getusermedia.browser.enabled", true);
+user_pref("media.navigator.permission.disabled", true);
+
+// Don't fetch Favico
+user_pref("browser.chrome.favicons", false);
+user_pref("browser.chrome.site_icons", false);
+
+// Allow proxying of 127.0.0.1/localhost
+user_pref("network.proxy.allow_hijacking_localhost", true);
+
+// Don't ask to save stuff to disk
+user_pref("browser.helperApps.neverAsk.saveToDisk", "application/octet-stream,text/plain");
+
+// Don't send silly data to Mozzila
+user_pref("extensions.blocklist.enabled", false);
+user_pref("browser.safebrowsing.downloads.remote.enabled", false);
+user_pref("messaging-system.rsexperimentloader.enabled", false);
+user_pref("browser.aboutHomeSnippets.updateUrl", "");
+user_pref("app.normandy.enabled", false);
+user_pref("network.captive-portal-service.enabled", false);
+user_pref("network.connectivity-service.enabled", false);
+user_pref("identity.fxaccounts.enabled", false);
+
+// Handle SSL errors and such without popping screens
+user_pref("security.insecure_field_warning.contextual.enabled", false);
+user_pref("security.certerrors.permanentOverride", false);
+user_pref("network.stricttransportsecurity.preloadlist", false);
+user_pref("security.enterprise_roots.enabled", true);
+
+// Disable Cache
+user_pref("browser.cache.disk.enable", false);
+user_pref("browser.cache.memory.enable", false);
+user_pref("browser.cache.offline.enable", false);
+user_pref("network.http.use-cache", false);
+user_pref("browser.cache.disk.capacity", 0);
+
+// Disable service workers
+user_pref("dom.serviceWorkers.enabled", false);
+
+// For finally disable external urls requests
+user_pref("app.update.url.details", "about:blank");
+user_pref("app.update.url.manual", "about:blank");
+user_pref("browser.safebrowsing.provider.google.updateURL", "about:blank");
+user_pref("browser.safebrowsing.provider.google4.updateURL", "about:blank");
+user_pref("browser.safebrowsing.provider.mozilla.updateURL", "about:blank");
+user_pref("extensions.update.background.url", "about:blank");
+user_pref("extensions.update.url", "about:blank");

--- a/firefox/readme.md
+++ b/firefox/readme.md
@@ -13,16 +13,16 @@ Auto-updatable every 12 hours (currently available only as [nightly alpha builds
 ### Docker Hub
 
 ```sh
-docker run -it --rm -p 9222:9222 nextools/firefox:<TAG>
+docker run -it --rm -p 9222:9222 neuralegion/nextools-firefox:<TAG>
 ```
 
-### GitHub Packages
+<!-- ### GitHub Packages
 
 ```sh
 docker run -it --rm -p 9222:9222 docker.pkg.github.com/nextools/images/firefox:<TAG>
 ```
 
-See [login caveats](../readme.md#github-packages) in the root readme.
+See [login caveats](../readme.md#github-packages) in the root readme. -->
 
 ### Puppeteer
 
@@ -52,19 +52,19 @@ await browser.close()
 Container uses a `RD_PORT` [environment variable](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file), which is `9222` by default:
 
 ```
-docker run -it --rm -p 9223:9223 -e RD_PORT=9223 nextools/firefox:<TAG>
+docker run -it --rm -p 9223:9223 -e RD_PORT=9223 neuralegion/nextools-firefox:<TAG>
 ```
 
 ### pass additional Firefox arguments
 
 ```
-docker run -it --rm -p 9222:9222 nextools/firefox:<TAG> --some-firefox-arg
+docker run -it --rm -p 9222:9222 neuralegion/nextools-firefox:<TAG> --some-firefox-arg
 ```
 
 ### add custom fonts
 
-It's possible to mount a folder with custom fonts to be used later by Firefox: 
+It's possible to mount a folder with custom fonts to be used later by Firefox:
 
 ```
-docker run -it --rm -p 9222:9222 -v $(pwd)/path/to/fonts:/home/firefox/.fonts nextools/firefox:<TAG>
+docker run -it --rm -p 9222:9222 -v $(pwd)/path/to/fonts:/home/firefox/.fonts neuralegion/nextools-firefox:<TAG>
 ```

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,11 @@
-# images
+# Images
 
-Monorepo of Docker images auto-published to [Docker Hub](https://hub.docker.com/repositories/nextools) and [GitHub Packages](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages).
+Monorepo of Docker images auto-published to [Docker Hub](https://hub.docker.com/repositories/neuralegion).
+ <!-- and [GitHub Packages](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages). -->
 
-## GitHub Packages
+<!-- ## GitHub Packages
 
 This is fantastic but [you have to login to GitHub Packages with Docker even to pull images](https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782):
 
 1. Generate a personal access token [here](https://github.com/settings/tokens) with `read:packages` scope
-2. Login with `docker login docker.pkg.github.com -u <GITHUB_USERNAME>` using the token instead of a password
+2. Login with `docker login docker.pkg.github.com -u <GITHUB_USERNAME>` using the token instead of a password -->


### PR DESCRIPTION
Add CI actions for building the chromium image and publish it into NL repository. Maintain on-schedule.yml and both Makefile and readme.md files. Copy firefox prefs.js file from firefox-headless-remote repository.

[NLJ-2377]

[NLJ-2377]: https://team-1602965683919.atlassian.net/browse/NLJ-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ