### PR TITLE
feat(headless): use headless mode chrome

### DIFF
--- a/chromium/entrypoint.sh
+++ b/chromium/entrypoint.sh
@@ -22,7 +22,7 @@ fi
   --disable-translate \
   --disable-ipc-flooding-protection \
   --disable-component-update \
-  --headless \
+  --headless=chrome \
   --hide-scrollbars \
   --ignore-certificate-errors \
   --ignore-certificate-errors-spki-list \

--- a/chromium/entrypoint.sh
+++ b/chromium/entrypoint.sh
@@ -37,4 +37,5 @@ fi
   --safebrowsing-disable-auto-update \
   --user-data-dir=/home/chromium/ \
   --window-size=1920,1080 \
+  --site-per-process\
   "$@"


### PR DESCRIPTION
There is not difference with headfull if you use a proper headless mode (i.e. --headless=chrome).

fix: [NLJ-4044]

[NLJ-4044]: https://team-1602965683919.atlassian.net/browse/NLJ-4044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ