### PR TITLE
fix(print): add print disable option

### DIFF
--- a/chrome/entrypoint.sh
+++ b/chrome/entrypoint.sh
@@ -22,6 +22,7 @@ fi
   --disable-translate \
   --disable-component-extensions-with-background-pages \
   --deny-permission-prompts \
+  --disable-print-preview \
   --noerrdialogs \
   --disable-hang-monitor \
   --disable-ipc-flooding-protection \


### PR DESCRIPTION
Add option to entrypoint.sh for disabling a print context menu that causes crashes of render process.