### PR TITLE
fix(chrome): run chrome in headless=chrome mode

### DIFF
--- a/chrome/entrypoint.sh
+++ b/chrome/entrypoint.sh
@@ -4,6 +4,9 @@ if [ "$(ls -A /home/chrome/.fonts/)" ]; then
   fc-cache -f -v
 fi
 
+ip=$(hostname --ip-address)
+socat tcp-listen:$RD_PORT,bind="$ip",fork tcp:127.0.0.1:$RD_PORT &
+
 (ulimit -n 65000 || true) && (ulimit -p 65000 || true) && exec google-chrome-stable \
   --enable-automation \
   --disable-background-networking \
@@ -27,7 +30,7 @@ fi
   --disable-hang-monitor \
   --disable-ipc-flooding-protection \
   --disable-component-update \
-  --headless \
+  --headless=chrome \
   --hide-scrollbars \
   --ignore-certificate-errors \
   --ignore-certificate-errors-spki-list \


### PR DESCRIPTION
Run chrome browser in headless=chrome mode.
Add socat fort forwarding as a workaround for https://bugs.chromium.org/p/chromium/issues/detail?id=1373872

NLJ-4044 #done 