### PR TITLE
fix(oopif): add 'site-per-process' flag

### DIFF
--- a/chrome/entrypoint.sh
+++ b/chrome/entrypoint.sh
@@ -45,4 +45,5 @@ socat tcp-listen:$RD_PORT,bind="$ip",fork tcp:127.0.0.1:$RD_PORT &
   --safebrowsing-disable-auto-update \
   --user-data-dir=/home/chrome/ \
   --window-size=1920,1080 \
+  --site-per-process
   "$@"


### PR DESCRIPTION
This flag required to run iframe as oopif correctly

[TM-100]

[TM-100]: https://team-1602965683919.atlassian.net/browse/TM-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ