### PR TITLE
feat: switch to chrome 127

### DIFF
--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
 
 ARG VERSION
 ARG DEBIAN_FRONTEND=noninteractive

--- a/chrome/Makefile
+++ b/chrome/Makefile
@@ -1,7 +1,7 @@
 .PHONY: get-version build test tags
 
 CURRENT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-VERSION:="122.0.6261.111-1"
+VERSION:="127.0.6533.88-1"
 
 # get-version:
 # 	@docker pull ubuntu:bionic > /dev/null 2>&1


### PR DESCRIPTION
Change the method of obtaining chrome version and installing chrome: download it from the repo instead of a direct .deb download.

TM-1970 #code-review