### PR TITLE
feat: switch to chrome-headless-shell 134.0.6998.165

### DIFF
--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -1,29 +1,27 @@
-FROM ubuntu:bionic
+FROM ubuntu:latest
 
 ARG VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 ENV DBUS_SESSION_BUS_ADDRESS disabled:
 ENV RD_PORT=9222
 
-RUN apt-get update \
-    # https://github.com/phusion/baseimage-docker/issues/319
-    && apt-get install --yes apt-utils 2>&1 | grep -v "debconf: delaying package configuration, since apt-utils is not installed" \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
-    && sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] https://dl-ssl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${VERSION}_amd64.deb \
-    && apt-get update \
-    && apt-get install -y /tmp/chrome.deb fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dumb-init socat dbus dbus-x11 \
-      --no-install-recommends \
-    && service dbus start \
-    && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r chrome && useradd --create-home -rm -g chrome -G audio,video chrome
+RUN apt-get update -y
+RUN apt-get install wget unzip socat apt-utils -y --no-install-recommends
+RUN wget -q --no-check-certificate https://storage.googleapis.com/chrome-for-testing-public/${VERSION}/linux64/chrome-headless-shell-linux64.zip
+RUN unzip chrome-headless-shell-linux64.zip
+RUN rm chrome-headless-shell-linux64.zip
 
+RUN cat chrome-headless-shell-linux64/deb.deps | while read pkg ; do apt-get satisfy -y --no-install-recommends "${pkg}"; done
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mv chrome-headless-shell-linux64 /headless-shell
+RUN chmod +x /headless-shell/chrome-headless-shell
+RUN groupadd -r chrome && useradd --create-home -rm -g chrome -G audio,video chrome
 
 WORKDIR /home/chrome
 
 COPY --chown=chrome:chrome entrypoint.sh /home/chrome/
 
 USER chrome
-
-ENTRYPOINT ["dumb-init", "--", "/bin/sh", "/home/chrome/entrypoint.sh"]
+ENV PATH /headless-shell:$PATH
+ENTRYPOINT ["/bin/sh", "/home/chrome/entrypoint.sh"]

--- a/chrome/Makefile
+++ b/chrome/Makefile
@@ -1,7 +1,7 @@
 .PHONY: get-version build test tags
 
 CURRENT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-VERSION:="127.0.6533.88-1"
+VERSION:="134.0.6998.165"
 
 # get-version:
 # 	@docker pull ubuntu:bionic > /dev/null 2>&1

--- a/chrome/entrypoint.sh
+++ b/chrome/entrypoint.sh
@@ -9,7 +9,7 @@ RD_PORT="${RD_PORT:=9222}"
 ip=$(hostname --ip-address)
 socat tcp-listen:$RD_PORT,bind="$ip",fork tcp:127.0.0.1:$RD_PORT &
 
-(ulimit -n 65000 || true) && (ulimit -p 65000 || true) && exec google-chrome-stable \
+(ulimit -n 65000 || true) && (ulimit -p 65000 || true) && exec chrome-headless-shell \
   --enable-automation \
   --silent-debugger-extension-api \
   --allow-pre-commit-input \


### PR DESCRIPTION
```json
{
   "Browser": "HeadlessChrome/134.0.6998.165",
   "Protocol-Version": "1.3",
   "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/134.0.6998.165 Safari/537.36",
   "V8-Version": "13.4.114.21",
   "WebKit-Version": "537.36 (@fd886e2cb29dd984c13deec032832dee68d8abe3)",
   "webSocketDebuggerUrl": "ws://localhost:9222/devtools/browser/cf131583-19f4-433a-9cc2-6bab87b26ef9"
}
```

[TM-2485]

[TM-2485]: https://brightsec.atlassian.net/browse/TM-2485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ