### PR TITLE
chore: update chrome-headless-shell to 139.0.7258.154

### DIFF
--- a/chrome/Makefile
+++ b/chrome/Makefile
@@ -1,7 +1,7 @@
 .PHONY: get-version build test tags
 
 CURRENT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-VERSION:="134.0.6998.165"
+VERSION:="139.0.7258.154"
 
 # get-version:
 # 	@docker pull ubuntu:bionic > /dev/null 2>&1


### PR DESCRIPTION
```log
curl http://localhost:9222/json/version
{
   "Browser": "HeadlessChrome/139.0.7258.154",
   "Protocol-Version": "1.3",
   "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.154 Safari/537.36",
   "V8-Version": "13.9.205.21",
   "WebKit-Version": "537.36 (@9e0d6b2b47ffb17007b713429c9a302f9e43847f)",
   "webSocketDebuggerUrl": "ws://localhost:9222/devtools/browser/3a4c4242-78cf-42de-ab08-324ee2f01105"
}
```

[TM-2831]

[TM-2831]: https://brightsec.atlassian.net/browse/TM-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ