### PR TITLE
fix: prevent automatic considering samesite as Lax for Cookies

### DIFF
--- a/chrome/entrypoint.sh
+++ b/chrome/entrypoint.sh
@@ -4,6 +4,13 @@ if [ "$(ls -A /home/chrome/.fonts/)" ]; then
   fc-cache -f -v
 fi
 
+mkdir -p /home/chrome/policies
+cat > /home/chrome/policies/policy.json <<'EOF'
+{
+  "LegacySameSiteCookieBehaviorEnabled": 1
+}
+EOF
+
 RD_PORT="${RD_PORT:=9222}"
 
 ip=$(hostname --ip-address)
@@ -50,6 +57,7 @@ socat tcp-listen:$RD_PORT,bind="$ip",fork tcp:127.0.0.1:$RD_PORT &
   --use-mock-keychain \
   --disable-features=Translate,AcceptCHFrame,MediaRouter,OptimizationHints,ProcessPerSiteUpToMainFrameThreshold,ImprovedCookieControls \
   --enable-features=NetworkServiceInProcess2 \
+  --enterprise-policy-path=/home/chrome/policies \
   --hide-scrollbars \
   --ignore-certificate-errors \
   --ignore-certificate-errors-spki-list \


### PR DESCRIPTION
Create a directory for policies and add policy.json to enable LegacySameSiteCookieBehavior.