### PR TITLE
fix: update cosign-installer to v4.0.0 with cosign v3.0.4

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -38,7 +38,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+        uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: 'v3.0.4'
 
       - name: Get version
         id: get_version


### PR DESCRIPTION
- Upgrade from sigstore/cosign-installer@v3.5.0 (cosign v2.2.4) to @v4.0.0
- Explicitly set cosign-release to v3.0.4 for consistency across all workflows
- Ensures OCI 1.1 signature format compatibility