### PR TITLE
fix: socat bind on 0.0.0.0 for service container compatibility

### DIFF
--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -7,7 +7,7 @@ ENV RD_PORT=9222
 # Install socat (required for port forwarding)
 USER root
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends socat && \
+    apt-get install -y --no-install-recommends socat curl && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN groupadd -r chrome 2>/dev/null || true && \

--- a/chrome/entrypoint.sh
+++ b/chrome/entrypoint.sh
@@ -6,8 +6,7 @@ fi
 
 RD_PORT="${RD_PORT:=9222}"
 
-ip=$(hostname --ip-address)
-socat tcp-listen:$RD_PORT,bind="$ip",fork tcp:127.0.0.1:$RD_PORT &
+socat tcp-listen:$RD_PORT,reuseaddr,fork tcp:127.0.0.1:$(($RD_PORT + 1)) &
 
 (ulimit -n 65000 || true) && (ulimit -p 65000 || true) && exec /headless-shell/headless-shell \
   --enable-automation \
@@ -60,7 +59,7 @@ socat tcp-listen:$RD_PORT,bind="$ip",fork tcp:127.0.0.1:$RD_PORT &
   --no-sandbox \
   --no-default-browser-check \
   --remote-debugging-address=127.0.0.1 \
-  --remote-debugging-port="$RD_PORT" \
+  --remote-debugging-port="$(($RD_PORT + 1))" \
   --user-data-dir=/home/chrome/ \
   --window-size=1920,1080 \
   --window-position=0,0 \


### PR DESCRIPTION
Fix Chrome container not working as GitHub Actions service container.

Problems:
- socat bound to hostname IP which doesn't resolve correctly in service containers
- No curl/wget for health checks
- Chrome and socat used same port (conflict)

Fix:
- socat listens on 0.0.0.0:9222, forwards to localhost:9223
- Chrome listens on 127.0.0.1:9223
- curl added for health check support

Ref: TM-3653