### PR TITLE
revert: chromedp/headless-shell migration (PR #35)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -9,121 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-chrome:
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      id-token: write
-      contents: read
-
-    strategy:
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            platform: linux/amd64
-          - runner: ubuntu-24.04-arm
-            platform: linux/arm64
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ vars.AWS_DEFAULT_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Login into Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_BRIGHT_USER }}
-          password: ${{ secrets.DOCKERHUB_BRIGHT_TOKEN }}
-
-      - name: Build and push chrome (per-platform)
-        uses: docker/build-push-action@v6
-        with:
-          context: ./chrome
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: |
-            brightsec/nextools-chrome:${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
-            454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-chrome:${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
-
-  merge-chrome-manifest:
-    runs-on: ubuntu-latest
-    needs: build-chrome
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ vars.AWS_DEFAULT_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Login into Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_BRIGHT_USER }}
-          password: ${{ secrets.DOCKERHUB_BRIGHT_TOKEN }}
-
-      - name: Create and push manifest list (Docker Hub)
-        run: |
-          docker buildx imagetools create \
-            --tag brightsec/nextools-chrome:latest \
-            brightsec/nextools-chrome:amd64 \
-            brightsec/nextools-chrome:arm64
-
-      - name: Create and push manifest list (ECR)
-        run: |
-          docker buildx imagetools create \
-            --tag 454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-chrome:latest \
-            454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-chrome:amd64 \
-            454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-chrome:arm64
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
-        with:
-          cosign-release: 'v3.0.4'
-
-      - name: Get image digest
-        id: get_digest
-        run: |
-          set -e
-          DIGEST=$(docker buildx imagetools inspect "454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-chrome:latest" --format '{{.Manifest.Digest}}')
-          if [[ -z "$DIGEST" || ! "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
-            echo "::error::Failed to extract valid digest"
-            exit 1
-          fi
-          echo "IMAGE_DIGEST=454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-chrome@${DIGEST}" >> $GITHUB_ENV
-
-      - name: Sign image with Cosign
-        run: cosign sign --yes "${IMAGE_DIGEST}"
-
-      - name: Verify signature
-        run: |
-          cosign verify \
-            --certificate-identity-regexp="^https://github.com/NeuraLegion/[^/]+/.+$" \
-            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-            "${IMAGE_DIGEST}"
-
-  build-legacy:
+  build:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -135,6 +21,7 @@ jobs:
         package:
           - chromium
           - chromium-headful
+          - chrome
 
     steps:
       - name: Checkout
@@ -157,7 +44,7 @@ jobs:
 
       - name: Get version
         id: get_version
-        run: echo "result=$(make --file ${{ matrix.package }}/Makefile get-version)" >> $GITHUB_OUTPUT
+        run: echo ::set-output name=result::$(make --file ${{ matrix.package }}/Makefile get-version)
 
       - name: Build image
         run: make --file ${{ matrix.package }}/Makefile build version=${{ steps.get_version.outputs.result }}
@@ -172,16 +59,32 @@ jobs:
         run: docker push 454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-${{ matrix.package }}
 
       - name: Sign image with Cosign
+        shell: bash
         env:
           REGISTRY_ENDPOINT: 454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-${{ matrix.package }}
         run: |
           DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${REGISTRY_ENDPOINT}:latest" | cut -d'@' -f2)
+          if [[ -z "$DIGEST" || ! "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "::error::Failed to extract valid digest from pushed image"
+            exit 1
+          fi
           echo "IMAGE_DIGEST=${REGISTRY_ENDPOINT}@${DIGEST}" >> $GITHUB_ENV
-          cosign sign --yes "${REGISTRY_ENDPOINT}@${DIGEST}"
+          if ! cosign sign --yes "${REGISTRY_ENDPOINT}@${DIGEST}"; then
+            echo "::error::Failed to sign image. Check OIDC token availability, ECR permissions, and network connectivity."
+            exit 1
+          fi
 
       - name: Verify signature
+        shell: bash
         run: |
-          cosign verify \
+          if [[ -z "${IMAGE_DIGEST}" ]]; then
+            echo "::error::IMAGE_DIGEST not set"
+            exit 1
+          fi
+          if ! cosign verify \
             --certificate-identity-regexp="^https://github.com/NeuraLegion/[^/]+/.+$" \
             --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-            "${IMAGE_DIGEST}"
+            "${IMAGE_DIGEST}"; then
+            echo "::error::Signature verification failed. The image may not have been signed correctly."
+            exit 1
+          fi

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -1,21 +1,27 @@
-# chromedp/headless-shell v139.0.7258.155
-# TODO: Fork upstream repo or mirror to internal registry before production use (security review required)
-FROM chromedp/headless-shell@sha256:ab3598f600417861066c8e1002ef355423b97b3365e3b8f5cf36c12ebc9f3637
+FROM ubuntu:latest
 
+ARG VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+ENV DBUS_SESSION_BUS_ADDRESS disabled:
 ENV RD_PORT=9222
 
-# Install socat (required for port forwarding)
-USER root
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends socat && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update -y
+RUN apt-get install wget unzip socat apt-utils -y --no-install-recommends
+RUN wget -q --no-check-certificate https://storage.googleapis.com/chrome-for-testing-public/${VERSION}/linux64/chrome-headless-shell-linux64.zip
+RUN unzip chrome-headless-shell-linux64.zip
+RUN rm chrome-headless-shell-linux64.zip
 
-RUN groupadd -r chrome 2>/dev/null || true && \
-    useradd --create-home -rm -g chrome -G audio,video chrome 2>/dev/null || true
+RUN cat chrome-headless-shell-linux64/deb.deps | while read pkg ; do apt-get satisfy -y --no-install-recommends "${pkg}"; done
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mv chrome-headless-shell-linux64 /headless-shell
+RUN chmod +x /headless-shell/chrome-headless-shell
+RUN groupadd -r chrome && useradd --create-home -rm -g chrome -G audio,video chrome
 
 WORKDIR /home/chrome
 
 COPY --chown=chrome:chrome entrypoint.sh /home/chrome/
 
 USER chrome
+ENV PATH /headless-shell:$PATH
 ENTRYPOINT ["/bin/sh", "/home/chrome/entrypoint.sh"]

--- a/chrome/Makefile
+++ b/chrome/Makefile
@@ -1,20 +1,32 @@
 .PHONY: get-version build test tags
 
 CURRENT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+VERSION:="139.0.7258.154"
+
+# get-version:
+# 	@docker pull ubuntu:bionic > /dev/null 2>&1
+# 	@docker run --rm \
+# 		ubuntu:bionic \
+# 		sh -c "apt-get update --quiet=2 && apt-cache policy chromium-browser | sed --regexp-extended --quiet 's/.*Candidate: ([0-9.]+)-.+/\1/p'"
 
 get-version:
-	@docker pull --quiet chromedp/headless-shell:stable > /dev/null 2>&1
-	@docker inspect chromedp/headless-shell:stable --format '{{index .Config.Labels "org.opencontainers.image.version"}}' 2>/dev/null || echo "stable"
+	@echo $(VERSION)
 
 build:
-	@docker buildx build --platform linux/amd64,linux/arm64 \
-		--tag brightsec/nextools-chrome \
-		--tag 454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-chrome \
-		--push $(CURRENT_DIR)
-
-build-local:
-	@docker build --tag brightsec/nextools-chrome $(CURRENT_DIR)
+	@docker build --tag brightsec/nextools-chrome --tag 454884832027.dkr.ecr.us-east-1.amazonaws.com/nextools-chrome --build-arg VERSION=$(VERSION) $(CURRENT_DIR)
 
 test:
 	@docker run --detach --publish 9222:9222 --name nextools-chrome brightsec/nextools-chrome
 	@timeout 20s sh -c "trap 'docker container rm --force nextools-chrome' 0; until curl http://localhost:9222/json/version; do sleep 1; done"
+
+tags:
+	@for i in 3 2 1 0 -1; do \
+		if [ $$i -ge 0 ]; then \
+			tag=`echo $(version) | sed --regexp-extended "s/(\.[0-9]+){$$i}$$//"`; \
+		else \
+			tag=latest; \
+		fi; \
+		echo $$tag; \
+		docker tag nextools-chrome brightsec/nextools-chrome:$$tag; \
+		git tag --force nextools-chrome@$$tag; \
+	done

--- a/chrome/entrypoint.sh
+++ b/chrome/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -d /home/chrome/.fonts ] && [ "$(ls -A /home/chrome/.fonts/)" ]; then
+if [ "$(ls -A /home/chrome/.fonts/)" ]; then
   fc-cache -f -v
 fi
 
@@ -9,7 +9,7 @@ RD_PORT="${RD_PORT:=9222}"
 ip=$(hostname --ip-address)
 socat tcp-listen:$RD_PORT,bind="$ip",fork tcp:127.0.0.1:$RD_PORT &
 
-(ulimit -n 65000 || true) && (ulimit -p 65000 || true) && exec /headless-shell/headless-shell \
+(ulimit -n 65000 || true) && (ulimit -p 65000 || true) && exec chrome-headless-shell \
   --enable-automation \
   --silent-debugger-extension-api \
   --allow-pre-commit-input \
@@ -41,6 +41,7 @@ socat tcp-listen:$RD_PORT,bind="$ip",fork tcp:127.0.0.1:$RD_PORT &
   --disable-hang-monitor \
   --disable-ipc-flooding-protection \
   --disable-component-update \
+  --headless=old \
   --export-tagged-pdf \
   --force-color-profile=srgb \
   --no-zygote \


### PR DESCRIPTION
Revert the chromedp/headless-shell migration. Waiting for official ARM64 Chrome for Linux from Google (https://blog.google/chromium/bringing-chrome-to-arm64-linux-devices/) before switching away from Chrome for Testing.

The at_xpath retry fix in devtools-protocol is already merged and works with both old and new headless modes.

Ref: TM-3653